### PR TITLE
feat: add left-side trim functionality to video clips and fix clip ov…

### DIFF
--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -77,6 +77,7 @@ export default function BottomBar() {
           ? lastKeyframe.timestamp + 1 + lastKeyframe.duration
           : 0,
         duration,
+        startOffset: 0,
       });
       return db.keyFrames.find(newId.toString());
     },

--- a/src/components/video-preview.tsx
+++ b/src/components/video-preview.tsx
@@ -136,8 +136,10 @@ const VideoTrackSequence: React.FC<TrackSequenceProps> = ({
 
         const duration = frame.duration || resolveDuration(media) || 5000;
         const durationInFrames = Math.floor(duration / (1000 / FPS));
-        const startTime = frame.startTime || 0;
-        const startTimeInFrames = Math.floor(startTime / (1000 / FPS));
+        const startOffset = frame.startOffset || 0;
+        const startOffsetInFrames = Math.floor(startOffset / (1000 / FPS));
+        const sourceVideoDuration = resolveDuration(media) || 5000;
+        const sourceVideoFrames = Math.floor(sourceVideoDuration / (1000 / FPS));
 
         return (
           <Sequence
@@ -148,8 +150,8 @@ const VideoTrackSequence: React.FC<TrackSequenceProps> = ({
           >
             {media.mediaType === "video" && (
               <Sequence
-                from={-startTimeInFrames}  // Offset video to start from trimmed position
-                durationInFrames={durationInFrames}
+                from={-startOffsetInFrames}  // Offset video to start from trimmed position
+                durationInFrames={sourceVideoFrames}  // Use full source video duration
               >
                 <Video src={mediaUrl} />
               </Sequence>

--- a/src/components/video-preview.tsx
+++ b/src/components/video-preview.tsx
@@ -136,6 +136,8 @@ const VideoTrackSequence: React.FC<TrackSequenceProps> = ({
 
         const duration = frame.duration || resolveDuration(media) || 5000;
         const durationInFrames = Math.floor(duration / (1000 / FPS));
+        const startTime = frame.startTime || 0;
+        const startTimeInFrames = Math.floor(startTime / (1000 / FPS));
 
         return (
           <Sequence
@@ -144,7 +146,14 @@ const VideoTrackSequence: React.FC<TrackSequenceProps> = ({
             durationInFrames={durationInFrames}
             premountFor={3000}
           >
-            {media.mediaType === "video" && <Video src={mediaUrl} />}
+            {media.mediaType === "video" && (
+              <Sequence
+                from={-startTimeInFrames}  // Offset video to start from trimmed position
+                durationInFrames={durationInFrames}
+              >
+                <Video src={mediaUrl} />
+              </Sequence>
+            )}
             {media.mediaType === "image" && (
               <Img src={mediaUrl} style={{ objectFit: "cover" }} />
             )}

--- a/src/components/video/track.tsx
+++ b/src/components/video/track.tsx
@@ -272,7 +272,7 @@ export function VideoTrackView({
     const startWidth = trackElement.offsetWidth;
     const startLeft = trackElement.offsetLeft;
     const startTimestamp = frame.timestamp;
-    const originalStartTime = frame.startTime || 0;
+    const originalStartOffset = frame.startOffset || 0;
     const originalDuration = frame.duration;
 
     const handleMouseMove = (moveEvent: MouseEvent) => {
@@ -284,7 +284,6 @@ export function VideoTrackView({
       const maxDuration: number = resolveDuration(media) ?? 5000;
 
       if (direction === "left") {
-        // Calculate new position and width while maintaining the end point
         const endPoint = startLeft + startWidth;
         
         // Calculate new left position in percentage
@@ -307,7 +306,7 @@ export function VideoTrackView({
         // Calculate how much of the original video we're trimming from the start
         const trimAmount = startWidth - newWidth;
         const trimTime = (trimAmount / bounds.parentWidth) * 30 * 1000;
-        frame.startTime = originalStartTime + trimTime;
+        frame.startOffset = originalStartOffset + trimTime;
       }
 
       let newDuration = (newWidth / bounds.parentWidth) * 30 * 1000;
@@ -321,10 +320,10 @@ export function VideoTrackView({
           newLeft = endPoint - newWidth;
           frame.timestamp = (newLeft / bounds.parentWidth) * 30 * 1000;
           
-          // Recalculate startTime based on how much we trimmed
+          // Recalculate startOffset based on how much we trimmed
           const trimAmount = startWidth - newWidth;
           const trimTime = (trimAmount / bounds.parentWidth) * 30 * 1000;
-          frame.startTime = originalStartTime + trimTime;
+          frame.startOffset = originalStartOffset + trimTime;
         }
       } else if (newDuration > maxDuration) {
         newDuration = maxDuration;
@@ -334,10 +333,10 @@ export function VideoTrackView({
           newLeft = endPoint - newWidth;
           frame.timestamp = (newLeft / bounds.parentWidth) * 30 * 1000;
           
-          // Recalculate startTime based on how much we trimmed
+          // Recalculate startOffset based on how much we trimmed
           const trimAmount = startWidth - newWidth;
           const trimTime = (trimAmount / bounds.parentWidth) * 30 * 1000;
-          frame.startTime = originalStartTime + trimTime;
+          frame.startOffset = originalStartOffset + trimTime;
         }
       }
 
@@ -353,7 +352,7 @@ export function VideoTrackView({
       // Round values to prevent floating point imprecision
       frame.duration = Math.round(frame.duration / 100) * 100;
       frame.timestamp = Math.round(frame.timestamp / 100) * 100;
-      frame.startTime = Math.round(frame.startTime / 100) * 100;
+      frame.startOffset = Math.round(frame.startOffset / 100) * 100;
       
       // Update styles with rounded values
       trackElement.style.width = `${((frame.duration / 30) * 100) / 1000}%`;
@@ -362,7 +361,7 @@ export function VideoTrackView({
       db.keyFrames.update(frame.id, { 
         duration: frame.duration,
         timestamp: frame.timestamp,
-        startTime: frame.startTime
+        startOffset: frame.startOffset
       });
       queryClient.invalidateQueries({
         queryKey: queryKeys.projectPreview(projectId),
@@ -426,7 +425,7 @@ export function VideoTrackView({
         </div>
         <div
           className={cn(
-            "p-px flex-1 items-center bg-repeat-x h-full max-h-full overflow-hidden relative"
+            "p-px flex-1 items-center bg-repeat-x h-full max-h-full overflow-hidden relative",
           )}
           style={
             imageUrl

--- a/src/components/video/track.tsx
+++ b/src/components/video/track.tsx
@@ -191,37 +191,40 @@ export function VideoTrackView({
 
   const trackRef = useRef<HTMLDivElement>(null);
 
-  const calculateBounds = () => {
-    const timelineElement = document.querySelector(".timeline-container");
+  const calculateBounds = (trackElement: HTMLElement) => {
+    const timelineElement = trackElement.closest(".timeline-container");
     const timelineRect = timelineElement?.getBoundingClientRect();
-    const trackElement = trackRef.current;
-    const trackRect = trackElement?.getBoundingClientRect();
+    const trackRect = trackElement.getBoundingClientRect();
+    const previousTrack = trackElement.previousElementSibling;
+    const nextTrack = trackElement.nextElementSibling;
 
-    if (!timelineRect || !trackRect || !trackElement)
-      return { left: 0, right: 0 };
+    if (!timelineElement || !timelineRect) return null;
 
-    const previousTrack = trackElement?.previousElementSibling;
-    const nextTrack = trackElement?.nextElementSibling;
-
-    const leftBound = previousTrack
-      ? previousTrack.getBoundingClientRect().right - (timelineRect?.left || 0)
+    const parentWidth = (timelineElement as HTMLElement).offsetWidth;
+    const leftBoundPixels = previousTrack
+      ? previousTrack.getBoundingClientRect().right - timelineRect.left
       : 0;
-    const rightBound = nextTrack
-      ? nextTrack.getBoundingClientRect().left -
-        (timelineRect?.left || 0) -
-        trackRect.width
+    const rightBoundPixels = nextTrack
+      ? nextTrack.getBoundingClientRect().left - timelineRect.left - trackRect.width
       : timelineRect.width - trackRect.width;
 
     return {
-      left: leftBound,
-      right: rightBound,
+      parentWidth,
+      timelineRect,
+      trackRect,
+      leftBoundPixels,
+      rightBoundPixels,
+      leftBoundPercent: (leftBoundPixels / parentWidth) * 100,
+      rightBoundPercent: (rightBoundPixels / parentWidth) * 100
     };
   };
 
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     const trackElement = trackRef.current;
     if (!trackElement) return;
-    const bounds = calculateBounds();
+    const bounds = calculateBounds(trackElement);
+    if (!bounds) return;
+    
     const startX = e.clientX;
     const startLeft = trackElement.offsetLeft;
 
@@ -229,17 +232,13 @@ export function VideoTrackView({
       const deltaX = moveEvent.clientX - startX;
       let newLeft = startLeft + deltaX;
 
-      if (newLeft < bounds.left) {
-        newLeft = bounds.left;
-      } else if (newLeft > bounds.right) {
-        newLeft = bounds.right;
+      if (newLeft < bounds.leftBoundPixels) {
+        newLeft = bounds.leftBoundPixels;
+      } else if (newLeft > bounds.rightBoundPixels) {
+        newLeft = bounds.rightBoundPixels;
       }
 
-      const timelineElement = trackElement.closest(".timeline-container");
-      const parentWidth = timelineElement
-        ? (timelineElement as HTMLElement).offsetWidth
-        : 1;
-      const newTimestamp = (newLeft / parentWidth) * 30;
+      const newTimestamp = (newLeft / bounds.parentWidth) * 30;
       frame.timestamp = (newTimestamp < 0 ? 0 : newTimestamp) * 1000;
 
       trackElement.style.left = `${((frame.timestamp / 30) * 100) / 1000}%`;
@@ -265,38 +264,87 @@ export function VideoTrackView({
     e.stopPropagation();
     const trackElement = trackRef.current;
     if (!trackElement) return;
+    
+    const bounds = calculateBounds(trackElement);
+    if (!bounds) return;
+
     const startX = e.clientX;
     const startWidth = trackElement.offsetWidth;
+    const startLeft = trackElement.offsetLeft;
+    const startTimestamp = frame.timestamp;
 
     const handleMouseMove = (moveEvent: MouseEvent) => {
       const deltaX = moveEvent.clientX - startX;
       let newWidth = startWidth + (direction === "right" ? deltaX : -deltaX);
+      let newLeft = startLeft;
 
       const minDuration = 1000;
       const maxDuration: number = resolveDuration(media) ?? 5000;
 
-      const timelineElement = trackElement.closest(".timeline-container");
-      const parentWidth = timelineElement
-        ? (timelineElement as HTMLElement).offsetWidth
-        : 1;
-      let newDuration = (newWidth / parentWidth) * 30 * 1000;
+      if (direction === "left") {
+        // Calculate new position and width while maintaining the end point
+        const endPoint = startLeft + startWidth;
+        
+        // Calculate new left position in percentage
+        const proposedLeftPercent = ((startLeft + deltaX) / bounds.parentWidth) * 100;
+        
+        // Ensure we don't go beyond the previous clip
+        const constrainedLeftPercent = Math.max(bounds.leftBoundPercent, proposedLeftPercent);
+        
+        // Calculate maximum left position based on minimum duration
+        const maxLeftPercent = ((endPoint - (minDuration / 1000 / 30) * bounds.parentWidth) / bounds.parentWidth) * 100;
+        
+        // Apply all constraints
+        newLeft = Math.min(maxLeftPercent, constrainedLeftPercent) * bounds.parentWidth / 100;
+        newWidth = endPoint - newLeft;
+        
+        // Update timestamp based on new position
+        const newTimestamp = (newLeft / bounds.parentWidth) * 30 * 1000;
+        frame.timestamp = Math.max(0, newTimestamp);
+      }
 
+      let newDuration = (newWidth / bounds.parentWidth) * 30 * 1000;
+
+      // Enforce duration constraints
       if (newDuration < minDuration) {
-        newWidth = (minDuration / 1000 / 30) * parentWidth;
         newDuration = minDuration;
+        newWidth = (minDuration / 1000 / 30) * bounds.parentWidth;
+        if (direction === "left") {
+          const endPoint = startLeft + startWidth;
+          newLeft = endPoint - newWidth;
+          frame.timestamp = (newLeft / bounds.parentWidth) * 30 * 1000;
+        }
       } else if (newDuration > maxDuration) {
-        newWidth = (maxDuration / 1000 / 30) * parentWidth;
         newDuration = maxDuration;
+        newWidth = (maxDuration / 1000 / 30) * bounds.parentWidth;
+        if (direction === "left") {
+          const endPoint = startLeft + startWidth;
+          newLeft = endPoint - newWidth;
+          frame.timestamp = (newLeft / bounds.parentWidth) * 30 * 1000;
+        }
       }
 
       frame.duration = newDuration;
       trackElement.style.width = `${((frame.duration / 30) * 100) / 1000}%`;
+      
+      if (direction === "left") {
+        trackElement.style.left = `${(frame.timestamp / 30 / 10).toFixed(2)}%`;
+      }
     };
 
     const handleMouseUp = () => {
+      // Round values to prevent floating point imprecision
       frame.duration = Math.round(frame.duration / 100) * 100;
+      frame.timestamp = Math.round(frame.timestamp / 100) * 100;
+      
+      // Update styles with rounded values
       trackElement.style.width = `${((frame.duration / 30) * 100) / 1000}%`;
-      db.keyFrames.update(frame.id, { duration: frame.duration });
+      trackElement.style.left = `${(frame.timestamp / 30 / 10).toFixed(2)}%`;
+      
+      db.keyFrames.update(frame.id, { 
+        duration: frame.duration,
+        timestamp: frame.timestamp 
+      });
       queryClient.invalidateQueries({
         queryKey: queryKeys.projectPreview(projectId),
       });
@@ -357,7 +405,9 @@ export function VideoTrackView({
           </div>
         </div>
         <div
-          className="p-px flex-1 items-center bg-repeat-x h-full max-h-full overflow-hidden relative"
+          className={cn(
+            "p-px flex-1 items-center bg-repeat-x h-full max-h-full overflow-hidden relative"
+          )}
           style={
             imageUrl
               ? {
@@ -370,6 +420,19 @@ export function VideoTrackView({
           {(media.mediaType === "music" || media.mediaType === "voiceover") && (
             <AudioWaveform data={media} />
           )}
+          <div
+            className={cn(
+              "absolute left-0 z-50 top-0 bg-black/20 group-hover:bg-black/40",
+              "rounded-md bottom-0 w-2 m-1 p-px cursor-ew-resize backdrop-blur-md text-white/40",
+              "transition-colors flex flex-col items-center justify-center text-xs tracking-tighter",
+            )}
+            onMouseDown={(e) => handleResize(e, "left")}
+          >
+            <span className="flex gap-[1px]">
+              <span className="w-px h-2 rounded bg-white/40" />
+              <span className="w-px h-2 rounded bg-white/40" />
+            </span>
+          </div>
           <div
             className={cn(
               "absolute right-0 z-50 top-0 bg-black/20 group-hover:bg-black/40",

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -96,6 +96,7 @@ export const db = {
       return db.put("keyFrames", {
         id: crypto.randomUUID(),
         ...keyFrame,
+        startOffset: keyFrame.startOffset ?? 0,
       });
     },
     async update(id: string, keyFrame: Partial<VideoKeyFrame>) {

--- a/src/data/schema.ts
+++ b/src/data/schema.ts
@@ -79,7 +79,6 @@ export type MediaItem = {
   input?: Record<string, any>;
   output?: Record<string, any>;
   url?: string;
-  rating?: "positive" | "negative";
   metadata?: Record<string, any>; // TODO: Define the metadata schema
 } & (
   | {
@@ -88,7 +87,6 @@ export type MediaItem = {
       requestId: string;
       input: Record<string, any>;
       output?: Record<string, any>;
-      rating?: "positive" | "negative";
     }
   | {
       kind: "uploaded";

--- a/src/data/schema.ts
+++ b/src/data/schema.ts
@@ -42,7 +42,7 @@ export type VideoKeyFrame = {
   id: string;
   timestamp: number;
   duration: number;
-  startTime: number;
+  startOffset: number;
   trackId: string;
   data: KeyFrameData;
 };
@@ -79,6 +79,7 @@ export type MediaItem = {
   input?: Record<string, any>;
   output?: Record<string, any>;
   url?: string;
+  rating?: "positive" | "negative";
   metadata?: Record<string, any>; // TODO: Define the metadata schema
 } & (
   | {
@@ -87,6 +88,7 @@ export type MediaItem = {
       requestId: string;
       input: Record<string, any>;
       output?: Record<string, any>;
+      rating?: "positive" | "negative";
     }
   | {
       kind: "uploaded";

--- a/src/data/schema.ts
+++ b/src/data/schema.ts
@@ -42,6 +42,7 @@ export type VideoKeyFrame = {
   id: string;
   timestamp: number;
   duration: number;
+  startTime: number;
   trackId: string;
   data: KeyFrameData;
 };


### PR DESCRIPTION
…erlap issues

Resolving [this issue](https://github.com/fal-ai-community/video-starter-kit/issues/49). Being able to trim videos on the left side is especially important for AI generation where the model often creates a brief lull at the start of videos before the action begins.

I also fixed a bug where if you trim a clip, move another clip into the newly empty track space, and then try to drag the first clip's slider back out, it would overlap the second clip, due to clip boundaries not being recalculated.